### PR TITLE
ignore trailing spaces when looking for http response code 2XX

### DIFF
--- a/stack-build
+++ b/stack-build
@@ -150,7 +150,7 @@ source_path="${build_path}/store.squashfs"
 curl_opts="-v --retry 10 --retry-connrefused --silent --fail"
 log "pushing image '${source_path}' to '${destination_path}'"
 # note: use retry, because pushing to JFrog was not 100% reliable during development of this script.
-curl ${curl_opts} -u "${creds_short}" -X PUT "${destination_path}" -T "${source_path}" 3>&1 1>&2 2>&3 | egrep -q '< HTTP.*2[0-9]{2}$'
+curl ${curl_opts} -u "${creds_short}" -X PUT "${destination_path}" -T "${source_path}" 3>&1 1>&2 2>&3 | egrep -q '^< HTTP.*2[0-9]{2}[[:space:]]*$'
 [[ $? -eq 0  ]] || err "failed to push image"
 
 # push the metadata to jfrog
@@ -159,7 +159,7 @@ log "pushing meta data '${source_path}' to '${destination_path}'"
 for source in $(cd store; find meta -type f)
 do
     log "pushing ${destination_path}/${source}"
-    curl ${curl_opts} -u "${creds_short}" -X PUT "${destination_path}/${source}" -T "store/${source}" 3>&1 1>&2 2>&3 | egrep -q '< HTTP.*2[0-9]{2}$'
+    curl ${curl_opts} -u "${creds_short}" -X PUT "${destination_path}/${source}" -T "store/${source}" 3>&1 1>&2 2>&3 | egrep -q '^< HTTP.*2[0-9]{2}[[:space:]]*$'
     if [ ! $? -eq 0 ]; then
         err "unable to push meta data file store/$source"
     fi


### PR DESCRIPTION
It seems that there are trailing spaces after the HTTP response code, ignore all of them when matching for the expected string